### PR TITLE
fix: add missing seek back

### DIFF
--- a/src/main/java/com/iyxan23/zipalignjava/ZipAlign.java
+++ b/src/main/java/com/iyxan23/zipalignjava/ZipAlign.java
@@ -252,9 +252,9 @@ public class ZipAlign {
                         ));
                     }
 
-                    file.seek(entryStart + 46); // go back to our prev location
                     soAligned = true;
                 }
+                file.seek(entryStart + 46); // go back to our prev location
             }
 
             // if this file is uncompressed, and it has not been aligned, we align it


### PR DESCRIPTION
Hi,

When running the new `zipalign-java-1.1.0.jar` I am getting the following exception:

```
Exception in thread "main" java.lang.RuntimeException: com.iyxan23.zipalignjava.InvalidZipException: assumed central directory entry at 16346313 doesn't start with a signature
        at com.iyxan23.zipalignjava.Main.main(Main.java:48)
Caused by: com.iyxan23.zipalignjava.InvalidZipException: assumed central directory entry at 16346313 doesn't start with a signature
        at com.iyxan23.zipalignjava.ZipAlign.alignZip(ZipAlign.java:208)
        at com.iyxan23.zipalignjava.ZipAlign.alignZip(ZipAlign.java:53)
        at com.iyxan23.zipalignjava.Main.main(Main.java:46)
```

I believe the problem is [here](https://github.com/iyxan23/zipalign-java/blob/11f38e654f75fa0c043482b206d60a655a5507f6/src/main/java/com/iyxan23/zipalignjava/ZipAlign.java#L225): we are reading from the file, but then [here](https://github.com/iyxan23/zipalign-java/blob/11f38e654f75fa0c043482b206d60a655a5507f6/src/main/java/com/iyxan23/zipalignjava/ZipAlign.java#L255) we are only seeking back if it's a .so file. The solution is to perform the seek in both cases.