### PR TITLE
Prevent shiftAmount overflow

### DIFF
--- a/src/main/java/com/iyxan23/zipalignjava/ZipAlign.java
+++ b/src/main/java/com/iyxan23/zipalignjava/ZipAlign.java
@@ -193,7 +193,7 @@ public class ZipAlign {
 
         // to keep track of how many bytes we've shifted through the whole file (because we're going to pad null bytes
         // to align)
-        short shiftAmount = 0;
+        int shiftAmount = 0;
 
         file.seek(centralDirOffset);
         byte[] entry = new byte[46]; // not including the filename, extra field, and file comment


### PR DESCRIPTION
The variable `shiftAmount` is a short. Previously, it was a sum of values between 1 and `alignment`, which was usually 4. However, with .so aligning, it is now a sum between 1 and 4096, which is very easy to overflow, resulting in a corrupted ZIP file. I have attached a small zip with dummy .so files, that when zipaligned it results in an invalid ZIP file. I have also found this issue in real apks. Upgrading `shiftAmount` to an int solves the issue.

```
$ java -jar ./zipalign-java-1.1.1.jar ./test.zip ./test2.zip 
Aligning zip ./test.zip
Zip aligned successfully, took 6ms
$ unzip -t ./test2.zip
Archive:  ./test2.zip
error [./test2.zip]:  missing 4294901760 bytes in zipfile
  (attempting to process anyway)
error: invalid zip file with overlapped components (possible zip bomb)
```