### PR TITLE
Read unsigned values properly

### DIFF
--- a/src/main/java/com/iyxan23/zipalignjava/UnsignedByteBufferWrapper.java
+++ b/src/main/java/com/iyxan23/zipalignjava/UnsignedByteBufferWrapper.java
@@ -1,0 +1,29 @@
+package com.iyxan23.zipalignjava;
+
+// A ByteBuffer wrapper for working with unsigned values
+
+import java.nio.ByteBuffer;
+
+class UnsignedByteBufferWrapper {
+    private ByteBuffer inner;
+
+    UnsignedByteBufferWrapper(ByteBuffer inner) {
+        this.inner = inner;
+    }
+
+    public int getUShort() {
+        return inner.getShort() & 0xffff;
+    }
+
+    public long getUInt() {
+        return inner.getInt() & 0xffffffffL;
+    }
+
+    public int getUShort(int index) {
+        return inner.getShort(index) & 0xffff;
+    }
+
+    public long getUInt(int index) {
+        return inner.getInt(index) & 0xffffffffL;
+    }
+}


### PR DESCRIPTION
This PR closes #12.

Implemented an `UnsignedByteBufferWrapper` class that simply wraps a `ByteBuffer` and provides functions to read unsigned `short` and `int`. The main aligning codebase will then make use of this class to read values from the zip.